### PR TITLE
chore: add security.txt

### DIFF
--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,0 +1,3 @@
+Contact: mailto:security@zaahir.ca
+Expires: 2027-04-27T23:59:00Z
+Preferred-Languages: en


### PR DESCRIPTION
## Summary

- Add `/.well-known/security.txt` with the shared security contact, expiry, and preferred language.
- Addresses the Cloudflare Security Center `security_txt_not_enabled` finding after the next deploy.

## Testing

- `bun run lint`
- `bun run check`
- `bun run build`
- `git diff --check`

## Post-Deploy Validation

- Verify `https://zaahir.ca/.well-known/security.txt` returns the committed content.
- Recheck Cloudflare Security Center after its next refresh.
