### PR TITLE
fix(ci): use bun dependabot ecosystem, hold TS at 6.x, split major/routine groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,29 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
+  # "bun" (not "npm") — the npm ecosystem does not read or update bun.lock,
+  # so it bumps package.json alone and leaves the lockfile stale, breaking
+  # `bun install --frozen-lockfile` in CI and on Cloudflare Workers Builds.
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 2
     groups:
-      all-dependencies:
+      routine-dependencies:
         update-types:
-          - "major"
           - "minor"
           - "patch"
+      major-dependencies:
+        update-types:
+          - "major"
+    ignore:
+      # typescript-eslint declares peer `typescript: ">=4.8.4 <6.1.0"`, so TS 7
+      # breaks lint/typecheck outright. Hold TypeScript at 6.x until
+      # typescript-eslint ships TS >=7 support:
+      # https://github.com/typescript-eslint/typescript-eslint/issues/10940
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "deps"
     labels:


### PR DESCRIPTION
## Summary

Proactive fix — `.github/dependabot.yml` here has the same misconfiguration that broke Dependabot builds in moollaza/repo-remover, moollaza/how-many-rakats, and moollaza/quick-budget: `package-ecosystem: "npm"` on a repo that uses `bun.lock`. No PR has hit this yet in zaahir.ca specifically, but it's the same latent bug — the npm ecosystem doesn't read or update `bun.lock`, so the next Dependabot PR would bump `package.json` alone, leaving the lockfile stale and breaking `bun install --frozen-lockfile` in CI / Cloudflare Workers Builds.

Also holding TypeScript at 6.x: TypeScript 7.0 (recently released) breaks `typescript-eslint` (peer range `>=4.8.4 <6.1.0`), confirmed in repo-remover and autobill, and this repo has `typescript-eslint` in its devDependencies.

## Changes

- `package-ecosystem: "npm"` → `"bun"`.
- Added `ignore` for `typescript` major updates, linking [typescript-eslint#10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940).
- Split `all-dependencies` into `routine-dependencies` (minor/patch) and `major-dependencies` (major), matching moollaza/autobill's existing pattern, so one incompatible major can't block an entire batch.

## Why

Catching this before it produces a broken build, the way it did in the other three repos, rather than after.

## How to verify

Ran:
- Confirmed this repo has `bun.lock` and both `typescript` and `typescript-eslint` in `package.json`.
- Verified against GitHub's supported-ecosystems reference that `bun` is a distinct `package-ecosystem` value from `npm`.

Not run: config-only change, no application code touched. No existing Dependabot PR to compare against — the real test is the next one Dependabot opens, which should update `package.json` and `bun.lock` together.

## What to look for

- The `bun` ecosystem value requires bun >= v1.1.39.
- Revisit the TypeScript ignore once typescript-eslint supports TS 7 — remove it rather than bumping around it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
