### PR TITLE
fix(ci): read installed Playwright version from node_modules, not package-lock.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - run: bun install --frozen-lockfile
       - name: Get installed Playwright version
         id: playwright-version
-        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")" >> $GITHUB_OUTPUT
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> $GITHUB_OUTPUT
       - name: Cache playwright binaries
         uses: actions/cache@v6
         id: playwright-cache


### PR DESCRIPTION
## Summary

zaahir.ca's E2E job has been silently broken since the npm→bun migration: the Playwright browser cache-key step still read `require('./package-lock.json'))`, which throws `MODULE_NOT_FOUND` every run since this repo uses `bun.lock`. The failure doesn't hard-stop the job — it silently produces an empty `PLAYWRIGHT_VERSION`, so the cache key never varies by version (`${OS}-playwright-`).

That collapsed key has been false-hitting a stale cache on every run. It didn't matter until PR #149 bumped `@playwright/test` 1.49.1 → 1.61.1 — the stale cache didn't have that browser build, `Install Playwright browsers` got skipped (cache falsely reported a hit), and every E2E test failed with `Executable doesn't exist`. Zero screenshots got submitted to Argos, which correctly reported all 15 known snapshots as "removed" for an empty build — not a visual regression from the dependency bump, as it first appeared.

## Changes

- `.github/workflows/ci.yml`: read the installed Playwright version from `require('@playwright/test/package.json').version` instead of parsing `package-lock.json`. Works under any package manager, no lockfile format assumptions.

## Why

Restores real Playwright browser caching (was silently broken, not just for this PR) and removes the false "visual regression" signal on #149/#150.

## How to verify

Ran: confirmed the failing step chain via `gh api .../jobs/{id}` — `Get installed Playwright version` succeeded (silently swallowing its own error), `Cache playwright binaries` reported a false hit, `Install Playwright browsers` was skipped, `bun run test` failed on `browserType.launch: Executable doesn't exist`.

Not run: haven't watched this PR's own CI complete yet — that's the real end-to-end verification, since it needs a real cache miss (first run under the new key) to prove browsers actually get installed.

## What to look for

- This PR's own CI should show `Install Playwright browsers` actually running (not skipped) on its first run, since the cache key changes.
- #149 and #150 should be re-triggered/rebased after this merges — their "15 removed" Argos result should turn into a real (or empty) diff once E2E actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
